### PR TITLE
Coerce all verify emails to lowercase for comparison

### DIFF
--- a/src/interaction-handlers/AddMembersRoleSelectHandler.ts
+++ b/src/interaction-handlers/AddMembersRoleSelectHandler.ts
@@ -63,7 +63,7 @@ class AddMembersRoleSelectHandler extends InteractionHandler {
     const emailsRaw = interaction.fields.getTextInputValue("emails");
     const emails = emailsRaw
       .split(/[\r?\n|\r|\n|,]+/g)
-      .map((email: string) => email.trim())
+      .map((email: string) => email.trim().toLowerCase())
       .filter(Boolean);
 
     if (emails.length === 0) {

--- a/src/interaction-handlers/VerifyHandler.ts
+++ b/src/interaction-handlers/VerifyHandler.ts
@@ -88,7 +88,7 @@ class VerifyHandler extends InteractionHandler {
       [this.verifyHacker, this.verifyOtherRole],
       {
         guildDocRef,
-        email: submitted.fields.getTextInputValue("email"),
+        email: submitted.fields.getTextInputValue("email").toLowerCase(),
         member,
       },
     );


### PR DESCRIPTION
# TL;DR

Fix emails being case sensitive when attendees try to verify
