### PR TITLE
add role for hackers that prefer to not disclose pronouns

### DIFF
--- a/src/commands/StartPronouns.ts
+++ b/src/commands/StartPronouns.ts
@@ -44,6 +44,12 @@ class StartPronouns extends BaseCommand {
           .setName("other_role")
           .setDescription("The other role.")
           .setRequired(true),
+      )
+      .addRoleOption((option) =>
+        option
+          .setName("hide_role")
+          .setDescription("The prefer not to disclose role.")
+          .setRequired(true),
       );
   }
 
@@ -61,6 +67,7 @@ class StartPronouns extends BaseCommand {
     const sheHerRole = interaction.options.getRole("she_her_role")!;
     const theyThemRole = interaction.options.getRole("they_them_role")!;
     const otherRole = interaction.options.getRole("other_role")!;
+    const hideRole = interaction.options.getRole("hide_role")!;
 
     const message = await channel.send({ embeds: [this.makePronounsEmbed()] });
     PRONOUN_REACTION_EMOJIS.forEach((emoji) => message.react(emoji));
@@ -80,6 +87,7 @@ class StartPronouns extends BaseCommand {
         sheHerRole: sheHerRole.id,
         theyThemRole: theyThemRole.id,
         otherRole: otherRole.id,
+        hideRole: hideRole.id
       },
       savedMessage: {
         messageId: message.id,
@@ -93,9 +101,10 @@ class StartPronouns extends BaseCommand {
       .setTitle("Set your pronouns by reacting to one or more of the emojis!")
       .setDescription(
         `${PRONOUN_REACTION_EMOJIS[0]} he/him\n` +
-          `${PRONOUN_REACTION_EMOJIS[1]} she/her\n` +
-          `${PRONOUN_REACTION_EMOJIS[2]} they/them\n` +
-          `${PRONOUN_REACTION_EMOJIS[3]} other pronouns\n`,
+        `${PRONOUN_REACTION_EMOJIS[1]} she/her\n` +
+        `${PRONOUN_REACTION_EMOJIS[2]} they/them\n` +
+        `${PRONOUN_REACTION_EMOJIS[3]} other pronouns\n` +
+        `${PRONOUN_REACTION_EMOJIS[4]} prefer not to disclose\n`,
       );
   }
 }

--- a/src/listeners/pronouns/PronounsReactionAdd.ts
+++ b/src/listeners/pronouns/PronounsReactionAdd.ts
@@ -23,10 +23,16 @@ class PronounsReactionAdd extends Listener<typeof Events.MessageReactionAdd> {
     const { savedMessage } = pronounsDocData;
     if (reaction.message.id !== savedMessage.messageId) return;
 
-    const { heHimRole, sheHerRole, theyThemRole, otherRole } =
+    const { heHimRole, sheHerRole, theyThemRole, otherRole, hideRole } =
       pronounsDocData.roleIds;
 
-    const roleOrder = [heHimRole, sheHerRole, theyThemRole, otherRole];
+    const roleOrder = [
+      heHimRole,
+      sheHerRole,
+      theyThemRole,
+      otherRole,
+      hideRole,
+    ].filter(Boolean);
 
     const roleIndex = PRONOUN_REACTION_EMOJIS.findIndex(
       (emoji) => emoji === reaction.emoji.name,

--- a/src/listeners/pronouns/PronounsReactionRemove.ts
+++ b/src/listeners/pronouns/PronounsReactionRemove.ts
@@ -25,10 +25,16 @@ class PronounsReactionRemove extends Listener<
     const { savedMessage } = pronounsDocData;
     if (reaction.message.id !== savedMessage.messageId) return;
 
-    const { heHimRole, sheHerRole, theyThemRole, otherRole } =
+    const { heHimRole, sheHerRole, theyThemRole, otherRole, hideRole } =
       pronounsDocData.roleIds;
 
-    const roleOrder = [heHimRole, sheHerRole, theyThemRole, otherRole];
+    const roleOrder = [
+      heHimRole,
+      sheHerRole,
+      theyThemRole,
+      otherRole,
+      hideRole,
+    ].filter(Boolean);
 
     const roleIndex = PRONOUN_REACTION_EMOJIS.findIndex(
       (emoji) => emoji === reaction.emoji.name,

--- a/src/types/db/pronouns.ts
+++ b/src/types/db/pronouns.ts
@@ -6,8 +6,9 @@ export interface PronounsDoc {
     sheHerRole: string;
     theyThemRole: string;
     otherRole: string;
+    hideRole: string;
   };
   savedMessage: SavedMessage;
 }
 
-export const PRONOUN_REACTION_EMOJIS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣"];
+export const PRONOUN_REACTION_EMOJIS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣"];


### PR DESCRIPTION
# TL;DR
A fifth `hideRole` role is added for hackers who want to explicitly choose not to disclose their pronouns 

# Description

+ Updates Firestore types (`src/types/db/pronouns.ts`) to introduce the new role 
+ Updates `/start-pronouns` to allow the new role to be selectable & update Firestore
+ Updates pronouns embed to present the new role
+ Updates pronoun reaction (add and remove) listeners to handle the new role

## Why

Requested by cmd-f 2026

## Considerations

Types (`src/types/db/pronouns.ts`) will assume the new role exists, which will not be true for all previous discord servers. This shouldn't be a problem 