### PR TITLE
Feat/shift scheduling csv ingestion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,7 @@ ENV NAME=factotum
 
 ENV NODE_ENV=production
 
+# Shift schedule CSV times are parsed as server-local time
+ENV TZ=America/Vancouver
+
 CMD ["npm", "start"] 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sapphire/discord.js-utilities": "^7.3.3",
         "@sapphire/framework": "^5.3.6",
         "@sapphire/utilities": "^3.18.2",
+        "csv-parse": "^7.0.0",
         "discord.js": "^14.20.0",
         "dotenv": "^16.5.0",
         "firebase-admin": "^13.4.0"
@@ -2328,6 +2329,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.0.tgz",
+      "integrity": "sha512-CSssqPAK5us09FhMI9juM0jnqXUJP+rtWeIfivTYBLNH/8rnxkQlZvoRemF6MAyfNov9XU8mN2wwF/pP68sxTA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@sapphire/discord.js-utilities": "^7.3.3",
     "@sapphire/framework": "^5.3.6",
     "@sapphire/utilities": "^3.18.2",
+    "csv-parse": "^7.0.0",
     "discord.js": "^14.20.0",
     "dotenv": "^16.5.0",
     "firebase-admin": "^13.4.0"

--- a/src/commands/UploadSchedule.ts
+++ b/src/commands/UploadSchedule.ts
@@ -17,6 +17,9 @@ import { FieldValue, Timestamp } from "firebase-admin/firestore";
 // Firestore caps a write batch at 500 operations.
 const BATCH_LIMIT = 500;
 
+const MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1 MB
+const DOWNLOAD_TIMEOUT_MS = 10_000;
+
 const toShiftDoc = (shift: ParsedShift): ShiftDoc => ({
   startTime: Timestamp.fromDate(shift.startTime),
   durationMinutes: shift.durationMinutes,
@@ -69,17 +72,31 @@ class UploadSchedule extends BaseCommand {
     if (!file.name.toLowerCase().endsWith(".csv")) {
       return interaction.editReply({ content: "Please upload a `.csv` file." });
     }
-
-    let text: string;
-    try {
-      text = await (await fetch(file.url)).text();
-    } catch {
+    if (file.size > MAX_FILE_SIZE_BYTES) {
       return interaction.editReply({
-        content: "Failed to download the uploaded file. Please try again.",
+        content: `File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Please upload a CSV under 1 MB.`,
       });
     }
 
-    const { shifts, errors, duplicateRows } = parseScheduleCsv(text);
+    let text: string;
+    try {
+      const response = await fetch(file.url, {
+        signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        return interaction.editReply({
+          content: `Failed to download the uploaded file (HTTP ${response.status}). Please try again.`,
+        });
+      }
+      text = await response.text();
+    } catch {
+      return interaction.editReply({
+        content:
+          "Failed to download the uploaded file (network error or timeout). Please try again.",
+      });
+    }
+
+    const { shifts, errors } = parseScheduleCsv(text);
 
     if (errors.length > 0) {
       const report = formatErrors(errors);
@@ -103,7 +120,8 @@ class UploadSchedule extends BaseCommand {
       return interaction.editReply({ content: "No shifts found in the file." });
     }
 
-    // Replace the existing schedule: clear the shifts subcollection, then write the new set.
+    // Replace the existing schedule atomically: deletes, writes, and metadata
+    // go in a single batch so a failure leaves the old schedule intact.
     const scheduleDocRef = getGuildDocRef(guild.id)
       .collection("command-data")
       .doc("shift-schedule");
@@ -111,25 +129,22 @@ class UploadSchedule extends BaseCommand {
     const { firestore } = shiftsCollection;
 
     const existing = await shiftsCollection.listDocuments();
-    for (let i = 0; i < existing.length; i += BATCH_LIMIT) {
-      const batch = firestore.batch();
-      for (const ref of existing.slice(i, i + BATCH_LIMIT)) batch.delete(ref);
-      await batch.commit();
+    if (existing.length + shifts.length + 1 > BATCH_LIMIT) {
+      return interaction.editReply({
+        content: `Schedule is too large to replace atomically (existing + new shifts must be under ${BATCH_LIMIT - 1}). Nothing was saved.`,
+      });
     }
 
-    const shiftDocs = shifts.map(toShiftDoc);
-    for (let i = 0; i < shiftDocs.length; i += BATCH_LIMIT) {
-      const batch = firestore.batch();
-      for (const data of shiftDocs.slice(i, i + BATCH_LIMIT)) {
-        batch.set(shiftsCollection.doc(), data);
-      }
-      await batch.commit();
-    }
-
-    await scheduleDocRef.set(
+    const batch = firestore.batch();
+    for (const ref of existing) batch.delete(ref);
+    for (const shift of shifts)
+      batch.set(shiftsCollection.doc(), toShiftDoc(shift));
+    batch.set(
+      scheduleDocRef,
       { active: true, lastUpdated: FieldValue.serverTimestamp() },
       { merge: true },
     );
+    await batch.commit();
 
     await logToAdminLog(
       guild,
@@ -147,12 +162,6 @@ class UploadSchedule extends BaseCommand {
         value: `${earliest.toLocaleString()} → ${latest.toLocaleString()}`,
       },
     );
-    if (duplicateRows.length > 0) {
-      embed.addFields({
-        name: "Duplicate rows skipped",
-        value: duplicateRows.join(", "),
-      });
-    }
 
     return interaction.editReply({ embeds: [embed] });
   }

--- a/src/commands/UploadSchedule.ts
+++ b/src/commands/UploadSchedule.ts
@@ -1,0 +1,161 @@
+import BaseCommand from "@/classes/BaseCommand";
+import { idHints } from "@/constants/id-hints";
+import { ShiftDoc } from "@/types/db/shift-schedule";
+import { getGuildDocRef, logToAdminLog } from "@/util/nwplus-firestore";
+import { ParsedShift, parseScheduleCsv, RowError } from "@/util/schedule-csv";
+
+import { ApplyOptions } from "@sapphire/decorators";
+import { Command, CommandOptionsRunTypeEnum } from "@sapphire/framework";
+import {
+  AttachmentBuilder,
+  EmbedBuilder,
+  MessageFlags,
+  SlashCommandBuilder,
+} from "discord.js";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+
+// Firestore caps a write batch at 500 operations.
+const BATCH_LIMIT = 500;
+
+const toShiftDoc = (shift: ParsedShift): ShiftDoc => ({
+  startTime: Timestamp.fromDate(shift.startTime),
+  durationMinutes: shift.durationMinutes,
+  location: shift.location,
+  description: shift.description,
+  organizerEmails: shift.organizerEmails,
+  shiftLeadEmails: shift.shiftLeadEmails,
+  organizerIds: [],
+  shiftLeadIds: [],
+  ...(shift.channelId && { channelId: shift.channelId }),
+  ...(shift.link && { link: shift.link }),
+  pingSent: false,
+  completed: false,
+});
+
+const formatErrors = (errors: RowError[]): string =>
+  errors
+    .map((error) => `Row ${error.row}: ${error.messages.join("; ")}`)
+    .join("\n");
+
+@ApplyOptions<Command.Options>({
+  name: "upload-schedule",
+  description: "Upload a CSV schedule (replaces the existing one).",
+  runIn: CommandOptionsRunTypeEnum.GuildText,
+  preconditions: ["AdminRoleOnly"],
+})
+class UploadSchedule extends BaseCommand {
+  protected override buildCommand(builder: SlashCommandBuilder) {
+    return builder.addAttachmentOption((option) =>
+      option
+        .setName("file")
+        .setDescription("Schedule CSV file")
+        .setRequired(true),
+    );
+  }
+
+  protected override setCommandOptions() {
+    return {
+      idHints: [idHints.uploadSchedule],
+    };
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guild = interaction.guild!;
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    const file = interaction.options.getAttachment("file", true);
+    if (!file.name.toLowerCase().endsWith(".csv")) {
+      return interaction.editReply({ content: "Please upload a `.csv` file." });
+    }
+
+    let text: string;
+    try {
+      text = await (await fetch(file.url)).text();
+    } catch {
+      return interaction.editReply({
+        content: "Failed to download the uploaded file. Please try again.",
+      });
+    }
+
+    const { shifts, errors, duplicateRows } = parseScheduleCsv(text);
+
+    if (errors.length > 0) {
+      const report = formatErrors(errors);
+      const intro = `Could not upload schedule — ${errors.length} row(s) had errors and nothing was saved.`;
+      if (report.length <= 1800) {
+        return interaction.editReply({
+          content: `${intro}\n\`\`\`\n${report}\n\`\`\``,
+        });
+      }
+      return interaction.editReply({
+        content: intro,
+        files: [
+          new AttachmentBuilder(Buffer.from(report, "utf8"), {
+            name: "schedule-errors.txt",
+          }),
+        ],
+      });
+    }
+
+    if (shifts.length === 0) {
+      return interaction.editReply({ content: "No shifts found in the file." });
+    }
+
+    // Replace the existing schedule: clear the shifts subcollection, then write the new set.
+    const scheduleDocRef = getGuildDocRef(guild.id)
+      .collection("command-data")
+      .doc("shift-schedule");
+    const shiftsCollection = scheduleDocRef.collection("shifts");
+    const { firestore } = shiftsCollection;
+
+    const existing = await shiftsCollection.listDocuments();
+    for (let i = 0; i < existing.length; i += BATCH_LIMIT) {
+      const batch = firestore.batch();
+      for (const ref of existing.slice(i, i + BATCH_LIMIT)) batch.delete(ref);
+      await batch.commit();
+    }
+
+    const shiftDocs = shifts.map(toShiftDoc);
+    for (let i = 0; i < shiftDocs.length; i += BATCH_LIMIT) {
+      const batch = firestore.batch();
+      for (const data of shiftDocs.slice(i, i + BATCH_LIMIT)) {
+        batch.set(shiftsCollection.doc(), data);
+      }
+      await batch.commit();
+    }
+
+    await scheduleDocRef.set(
+      { active: true, lastUpdated: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+
+    await logToAdminLog(
+      guild,
+      `Shift schedule uploaded by <@${interaction.user.id}>: ${shifts.length} shift(s).`,
+    );
+
+    const startTimes = shifts.map((shift) => shift.startTime.getTime());
+    const earliest = new Date(Math.min(...startTimes));
+    const latest = new Date(Math.max(...startTimes));
+
+    const embed = new EmbedBuilder().setTitle("Schedule uploaded").addFields(
+      { name: "Shifts loaded", value: `${shifts.length}` },
+      {
+        name: "Date range",
+        value: `${earliest.toLocaleString()} → ${latest.toLocaleString()}`,
+      },
+    );
+    if (duplicateRows.length > 0) {
+      embed.addFields({
+        name: "Duplicate rows skipped",
+        value: duplicateRows.join(", "),
+      });
+    }
+
+    return interaction.editReply({ embeds: [embed] });
+  }
+}
+
+export default UploadSchedule;

--- a/src/constants/id-hints.ts
+++ b/src/constants/id-hints.ts
@@ -14,6 +14,7 @@ const devIdHints = {
   startTickets: "1402483611156086924",
   startTrivia: "1386423290645712967",
   startVerification: "1385475309876412540",
+  uploadSchedule: "",
 };
 
 const prodIdHints = {
@@ -27,6 +28,7 @@ const prodIdHints = {
   startTickets: "1404733926160728084",
   startTrivia: "1404734018066448448",
   startVerification: "1404734012332965969",
+  uploadSchedule: "",
 };
 
 export const idHints =

--- a/src/types/db/shift-schedule.ts
+++ b/src/types/db/shift-schedule.ts
@@ -1,0 +1,27 @@
+import { Timestamp } from "firebase-admin/firestore";
+
+// Metadata
+export interface ShiftScheduleDoc {
+  active: boolean;
+  lastUpdated: Timestamp;
+  /** Reserved for later PRs — default channel for reminder pings. */
+  defaultChannelId?: string;
+}
+
+export interface ShiftDoc {
+  startTime: Timestamp;
+  durationMinutes: number;
+  location: string;
+  description: string;
+  organizerEmails: string[];
+  shiftLeadEmails: string[];
+  // Populated in a later PR once emails are resolved to Discord IDs
+  organizerIds: string[];
+  shiftLeadIds: string[];
+  // Optional per-shift channel override for the reminder ping
+  channelId?: string;
+  // Optional link shown in the reminder
+  link?: string;
+  pingSent: boolean;
+  completed: boolean;
+}

--- a/src/util/schedule-csv.ts
+++ b/src/util/schedule-csv.ts
@@ -21,8 +21,6 @@ export interface RowError {
 export interface ParseResult {
   shifts: ParsedShift[];
   errors: RowError[];
-  // rows dropped as duplicates
-  duplicateRows: number[];
 }
 
 const REQUIRED_COLUMNS = [
@@ -147,7 +145,6 @@ export function parseScheduleCsv(content: string): ParseResult {
       errors: [
         { row: 1, messages: [`Could not parse file as CSV: ${message}`] },
       ],
-      duplicateRows: [],
     };
   }
 
@@ -155,7 +152,6 @@ export function parseScheduleCsv(content: string): ParseResult {
     return {
       shifts: [],
       errors: [{ row: 1, messages: ["File is empty."] }],
-      duplicateRows: [],
     };
   }
 
@@ -174,7 +170,6 @@ export function parseScheduleCsv(content: string): ParseResult {
           ],
         },
       ],
-      duplicateRows: [],
     };
   }
 
@@ -188,8 +183,7 @@ export function parseScheduleCsv(content: string): ParseResult {
 
   const shifts: ParsedShift[] = [];
   const errors: RowError[] = [];
-  const duplicateRows: number[] = [];
-  const seenKeys = new Set<string>();
+  const seenKeys = new Map<string, number>();
 
   for (let i = 1; i < rows.length; i++) {
     const rowNumber = i + 1; // header is row 1
@@ -200,19 +194,28 @@ export function parseScheduleCsv(content: string): ParseResult {
       continue;
     }
 
-    // dedupe valid rows
+    // rows identical in every field are duplicates, and fail the upload
     const duplicateKey = [
       shift.startTime.getTime(),
       shift.location.toLowerCase(),
       [...shift.organizerEmails].sort().join(","),
+      [...shift.shiftLeadEmails].sort().join(","),
+      shift.durationMinutes,
+      shift.description,
+      shift.channelId ?? "",
+      shift.link ?? "",
     ].join("|");
-    if (seenKeys.has(duplicateKey)) {
-      duplicateRows.push(rowNumber);
+    const firstSeenRow = seenKeys.get(duplicateKey);
+    if (firstSeenRow !== undefined) {
+      errors.push({
+        row: rowNumber,
+        messages: [`Duplicate of row ${firstSeenRow}.`],
+      });
       continue;
     }
-    seenKeys.add(duplicateKey);
+    seenKeys.set(duplicateKey, rowNumber);
     shifts.push(shift);
   }
 
-  return { shifts, errors, duplicateRows };
+  return { shifts, errors };
 }

--- a/src/util/schedule-csv.ts
+++ b/src/util/schedule-csv.ts
@@ -1,0 +1,218 @@
+import { parse } from "csv-parse/sync";
+
+export interface ParsedShift {
+  // server-local; becomes a Timestamp on write
+  startTime: Date;
+  durationMinutes: number;
+  location: string;
+  description: string;
+  organizerEmails: string[];
+  shiftLeadEmails: string[];
+  channelId?: string;
+  link?: string;
+}
+
+export interface RowError {
+  // spreadsheet row (header is row 1)
+  row: number;
+  messages: string[];
+}
+
+export interface ParseResult {
+  shifts: ParsedShift[];
+  errors: RowError[];
+  // rows dropped as duplicates
+  duplicateRows: number[];
+}
+
+const REQUIRED_COLUMNS = [
+  "organizer_emails",
+  "start_time",
+  "location",
+  "shift_leads",
+  "duration_minutes",
+  "description",
+] as const;
+const OPTIONAL_COLUMNS = ["channel_id", "link"] as const;
+const ALL_COLUMNS = [...REQUIRED_COLUMNS, ...OPTIONAL_COLUMNS];
+type ColumnName = (typeof ALL_COLUMNS)[number];
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const START_TIME_REGEX = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/;
+
+// split a cell into trimmed, lowercased emails
+const parseEmailList = (value: string): string[] =>
+  value
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter((email) => email.length > 0);
+
+// parse "YYYY-MM-DD HH:MM" (server-local); null if invalid or not a real date
+const parseStartTime = (value: string): Date | null => {
+  const match = START_TIME_REGEX.exec(value.trim());
+  if (!match) return null;
+  const [, year, month, day, hour, minute] = match.map(Number);
+  const date = new Date(year, month - 1, day, hour, minute);
+  // reject rolled-over dates like Feb 31
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day ||
+    date.getHours() !== hour ||
+    date.getMinutes() !== minute
+  ) {
+    return null;
+  }
+  return date;
+};
+
+// validate one row's fields -> a shift, or the problems found
+const validateRow = (
+  get: (column: ColumnName) => string,
+): { shift?: ParsedShift; messages: string[] } => {
+  const messages: string[] = [];
+
+  const organizerEmails = parseEmailList(get("organizer_emails"));
+  if (organizerEmails.length === 0) {
+    messages.push("organizer_emails is required (at least one email).");
+  } else {
+    const invalid = organizerEmails.filter((email) => !EMAIL_REGEX.test(email));
+    if (invalid.length > 0) {
+      messages.push(`Invalid organizer email(s): ${invalid.join(", ")}`);
+    }
+  }
+
+  const shiftLeadEmails = parseEmailList(get("shift_leads"));
+  const invalidLeads = shiftLeadEmails.filter(
+    (email) => !EMAIL_REGEX.test(email),
+  );
+  if (invalidLeads.length > 0) {
+    messages.push(`Invalid shift lead email(s): ${invalidLeads.join(", ")}`);
+  }
+
+  const startTime = parseStartTime(get("start_time"));
+  if (!startTime) {
+    messages.push(
+      'start_time must be a valid date in "YYYY-MM-DD HH:MM" format.',
+    );
+  }
+
+  const durationRaw = get("duration_minutes");
+  const durationMinutes = Number(durationRaw);
+  if (
+    durationRaw === "" ||
+    !Number.isInteger(durationMinutes) ||
+    durationMinutes <= 0
+  ) {
+    messages.push("duration_minutes must be a positive integer.");
+  }
+
+  // captured but not validated — degraded display at worst, mapping/send handles the rest
+  const location = get("location");
+  const description = get("description");
+  const channelId = get("channel_id");
+  const link = get("link");
+
+  if (!startTime || messages.length > 0) return { messages };
+
+  return {
+    messages,
+    shift: {
+      startTime,
+      durationMinutes,
+      location,
+      description,
+      organizerEmails,
+      shiftLeadEmails,
+      ...(channelId !== "" && { channelId }),
+      ...(link !== "" && { link }),
+    },
+  };
+};
+
+// parse + validate the schedule CSV; collects every error per row, no side effects
+export function parseScheduleCsv(content: string): ParseResult {
+  let rows: string[][];
+  try {
+    rows = parse(content, {
+      skip_empty_lines: true,
+      trim: true,
+      bom: true,
+      relax_column_count: true,
+    }) as string[][];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      shifts: [],
+      errors: [
+        { row: 1, messages: [`Could not parse file as CSV: ${message}`] },
+      ],
+      duplicateRows: [],
+    };
+  }
+
+  if (rows.length === 0) {
+    return {
+      shifts: [],
+      errors: [{ row: 1, messages: ["File is empty."] }],
+      duplicateRows: [],
+    };
+  }
+
+  const header = rows[0].map((column) => column.trim().toLowerCase());
+  const missingColumns = REQUIRED_COLUMNS.filter(
+    (column) => !header.includes(column),
+  );
+  if (missingColumns.length > 0) {
+    return {
+      shifts: [],
+      errors: [
+        {
+          row: 1,
+          messages: [
+            `Missing required column(s): ${missingColumns.join(", ")}`,
+          ],
+        },
+      ],
+      duplicateRows: [],
+    };
+  }
+
+  const columnIndex = Object.fromEntries(
+    ALL_COLUMNS.map((column) => [column, header.indexOf(column)]),
+  ) as Record<ColumnName, number>;
+  const cell = (row: string[], column: ColumnName): string => {
+    const index = columnIndex[column];
+    return index >= 0 ? (row[index] ?? "").trim() : "";
+  };
+
+  const shifts: ParsedShift[] = [];
+  const errors: RowError[] = [];
+  const duplicateRows: number[] = [];
+  const seenKeys = new Set<string>();
+
+  for (let i = 1; i < rows.length; i++) {
+    const rowNumber = i + 1; // header is row 1
+    const { shift, messages } = validateRow((column) => cell(rows[i], column));
+
+    if (!shift) {
+      errors.push({ row: rowNumber, messages });
+      continue;
+    }
+
+    // dedupe valid rows
+    const duplicateKey = [
+      shift.startTime.getTime(),
+      shift.location.toLowerCase(),
+      [...shift.organizerEmails].sort().join(","),
+    ].join("|");
+    if (seenKeys.has(duplicateKey)) {
+      duplicateRows.push(rowNumber);
+      continue;
+    }
+    seenKeys.add(duplicateKey);
+    shifts.push(shift);
+  }
+
+  return { shifts, errors, duplicateRows };
+}


### PR DESCRIPTION
# TL;DR

Adds `/upload-schedule` along with the shift-schedule Firestore schema and a
CSV parser. First PR for automated shift reminders - ingestion only, no
scheduler/pings yet.

# Description

New Feature. Lets organizers upload a shift CSV that gets validated and
stored in Firestore, replacing any existing schedule. Three commits: schema +
types, the CSV parser (csv-parse), and the `/upload-schedule` command.

Shifts are stored as a subcollection under `command-data/shift-schedule`.
Organizer Discord IDs are left empty for now - email→ID mapping, the
scheduler, and `/view-schedule` + `/manage-shifts` come in follow-up PRs.

## Why

Organizers need reminders sent only to the people on a given shift, but the
schedule has to live in the DB first.

## User Changes

- New admin-only `/upload-schedule` command that takes a CSV attachment.
- Validates the file and replaces the existing schedule; invalid files report
  the bad rows and save nothing.

## Tests Done

- Lint + typecheck clean.
- Uploaded valid / invalid / duplicate CSVs to a test server and confirmed the
  writes and replace behaviour in Firestore.

# Breaking Changes

None. Adds the `csv-parse` dependency; the `uploadSchedule` id-hint needs
filling in after the command first registers.
